### PR TITLE
Use unary_union instead of cascaded_union

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -5,9 +5,9 @@ name: Python package
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -12,20 +12,30 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    environment:
+      name: pypi
+      url: https://pypi.org/p/polygon-geohasher-2
+
+    permissions:
+      id-token: write
+
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
         python-version: '3.x'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+
+    - name: Build
       run: |
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+        
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1
+        

--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
-# polygon-geohasher
+# polygon-geohasher-2
+
+> [!NOTE]
+> This is a minimally maintained fork of the original
+> [Bonsanto/polygon-geohasher](https://github.com/Bonsanto/polygon-geohasher) repo, which does not appear to be
+> actively maintained.
+>
+> The original project is published to PyPi under the package name `polygon-geohasher`; *this* project is published
+> under the package name `polygon-geohasher-2`. My goal is to provide a stable package that works with all actively
+> maintained Python versions (those with a status of `bugfix` or `security`
+> [here](https://devguide.python.org/versions/)). I will likely *not* implement any feature enhancements, but
+> contributions are welcome!
+
+
 Polygon Geohasher is an open source Python package for converting Shapely's
 polygons into a set of geohashes. It obtains the set of geohashes
 inside a polygon or geohashes that touch (intersect) the polygon. This library uses
@@ -16,7 +29,7 @@ Polygon Geohasher requires:
 Linux users can get Polygon Geohasher from the Python Package Index with
 pip (8+):
 
-`$ pip install polygon-geohasher`
+`$ pip install polygon-geohasher-2`
 
 ## Usage
 Here are some simple examples:

--- a/polygon_geohasher/polygon_geohasher.py
+++ b/polygon_geohasher/polygon_geohasher.py
@@ -2,7 +2,7 @@ import geohash
 import queue
 
 from shapely import geometry
-from shapely.ops import cascaded_union
+from shapely.ops import unary_union
 
 
 def geohash_to_polygon(geo):
@@ -77,4 +77,4 @@ def geohashes_to_polygon(geohashes):
     :param geohashes: array-like. List of geohashes to form resulting polygon.
     :return: shapely geometry. Resulting Polygon after combining geohashes.
     """
-    return cascaded_union([geohash_to_polygon(g) for g in geohashes])
+    return unary_union([geohash_to_polygon(g) for g in geohashes])

--- a/polygon_geohasher/version.py
+++ b/polygon_geohasher/version.py
@@ -5,5 +5,5 @@ def _safe_int(string):
         return string
 
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 VERSION = tuple(_safe_int(x) for x in __version__.split("."))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-shapely>=1.6.3
-python-geohash>=0.8.5
-setuptools>=38.2.5
+shapely >=1.6.3, <2
+python-geohash >=0.8.5
+setuptools >=38.2.5

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,9 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     keywords=["polygon", "geohashes"],
 )

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,12 @@ def requirements():
 
 
 setup(
-    name="polygon-geohasher",
+    name="polygon-geohasher-2",
     version=get_version(),
-    author="Alberto Bonsanto",
+    author="Alberto Bonsanto; maintained by Jon Duckworth",
     author_email="",
-    url="https://github.com/Bonsanto/polygon-geohasher",
-    description="Wrapper over Shapely that returns the set of geohashes that form a Polygon",
+    url="https://github.com/duckontheweb/polygon-geohasher",
+    description="""Wrapper over Shapely that returns the set of geohashes that form a Polygon.""",
     long_description=readme(),
     license="MIT",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     url="https://github.com/duckontheweb/polygon-geohasher",
     description="""Wrapper over Shapely that returns the set of geohashes that form a Polygon.""",
     long_description=readme(),
+    long_description_content_type="text/markdown",
     license="MIT",
     packages=find_packages(),
     install_requires=requirements(),

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 from polygon_geohasher.polygon_geohasher import (
     polygon_to_geohashes,
@@ -6,6 +7,7 @@ from polygon_geohasher.polygon_geohasher import (
     geohashes_to_polygon,
 )
 from shapely import geometry
+from shapely.errors import ShapelyDeprecationWarning
 
 
 class TestSimpleMethods(unittest.TestCase):
@@ -37,6 +39,26 @@ class TestSimpleMethods(unittest.TestCase):
         polygon = geohashes_to_polygon(polygon_to_geohashes(test_polygon, 7, False))
 
         self.assertTrue(polygon.area >= test_polygon.area)
+
+
+class TestWarnings(unittest.TestCase):
+    def test_no_shapely_deprecation_warnings(self):
+        test_geohashes = ["x1", "x2"]
+
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            _ = geohashes_to_polygon(test_geohashes)
+        
+        captured_shapely_warnings = [w for w in captured_warnings if w.category == ShapelyDeprecationWarning]
+        failure_message = "".join([
+            warnings.formatwarning(w.message, w.category, w.filename, w.lineno, w.line)
+            for w in captured_shapely_warnings
+        ])
+        
+        self.assertEqual(
+            len(captured_shapely_warnings),
+            0,
+            msg=failure_message
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Uses `shapely.ops.unary_union` instead of `shapely.ops.cascaded_union` to avoid `ShapelyDeprecationWarning`s.

Also adds a regression test to check for these warnings when calling `geohashes_to_polygon`.

Closes #13 

