### PR TITLE
perf: speed up polygon_to_geohashes and add benchmarks

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install OS dependencies

--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip (8+):
 Here are some simple examples:
 
 ```python
-from polygon_geohasher.polygon_geohasher import polygon_to_geohashes, geohashes_to_polygon
+from polygon_geohasher import polygon_to_geohashes, geohashes_to_polygon
 from shapely import geometry
 
 polygon = geometry.Polygon([(-99.1795917, 19.432134), (-99.1656847, 19.429034),
@@ -30,6 +30,14 @@ polygon = geometry.Polygon([(-99.1795917, 19.432134), (-99.1656847, 19.429034),
 inner_geohashes_polygon = geohashes_to_polygon(polygon_to_geohashes(polygon, 7))
 outer_geohashes_polygon = geohashes_to_polygon(polygon_to_geohashes(polygon, 7, False))
 ```
+
+## Benchmarking
+Compare the optimized implementation against the legacy algorithm:
+
+`$ .venv/bin/python benchmarks/polygon_to_geohashes.py --iterations 5 --precision 7`
+
+Use `--inner` or `--outer` to focus on a single mode, and `--no-validate` to skip
+output validation.
 
 
 `geohash_to_polygon(geohash)`:

--- a/benchmarks/polygon_to_geohashes.py
+++ b/benchmarks/polygon_to_geohashes.py
@@ -1,0 +1,188 @@
+import argparse
+import os
+import queue
+import statistics
+import sys
+import time
+
+import geohash
+from shapely import geometry
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from polygon_geohasher import polygon_to_geohashes
+
+
+def legacy_geohash_to_polygon(geo):
+    lat_centroid, lng_centroid, lat_offset, lng_offset = geohash.decode_exactly(geo)
+    corner_1 = (lat_centroid - lat_offset, lng_centroid - lng_offset)[::-1]
+    corner_2 = (lat_centroid - lat_offset, lng_centroid + lng_offset)[::-1]
+    corner_3 = (lat_centroid + lat_offset, lng_centroid + lng_offset)[::-1]
+    corner_4 = (lat_centroid + lat_offset, lng_centroid - lng_offset)[::-1]
+    return geometry.Polygon([corner_1, corner_2, corner_3, corner_4, corner_1])
+
+
+def legacy_polygon_to_geohashes(polygon, precision, inner=True):
+    if polygon.is_empty:
+        return set()
+
+    inner_geohashes = set()
+    outer_geohashes = set()
+
+    envelope = polygon.envelope
+    centroid = polygon.centroid
+
+    testing_geohashes = queue.Queue()
+    testing_geohashes.put(geohash.encode(centroid.y, centroid.x, precision))
+
+    while not testing_geohashes.empty():
+        current_geohash = testing_geohashes.get()
+
+        if (
+            current_geohash not in inner_geohashes
+            and current_geohash not in outer_geohashes
+        ):
+            current_polygon = legacy_geohash_to_polygon(current_geohash)
+
+            condition = (
+                envelope.contains(current_polygon)
+                if inner
+                else envelope.intersects(current_polygon)
+            )
+
+            if condition:
+                if inner:
+                    if polygon.contains(current_polygon):
+                        inner_geohashes.add(current_geohash)
+                    else:
+                        outer_geohashes.add(current_geohash)
+                else:
+                    if polygon.intersects(current_polygon):
+                        inner_geohashes.add(current_geohash)
+                    else:
+                        outer_geohashes.add(current_geohash)
+                for neighbor in geohash.neighbors(current_geohash):
+                    if (
+                        neighbor not in inner_geohashes
+                        and neighbor not in outer_geohashes
+                    ):
+                        testing_geohashes.put(neighbor)
+
+    return inner_geohashes
+
+
+def build_polygons():
+    triangle = geometry.Polygon(
+        [
+            (-99.1795917, 19.432134),
+            (-99.1656847, 19.429034),
+            (-99.1776492, 19.414236),
+            (-99.1795917, 19.432134),
+        ]
+    )
+
+    center = geometry.Point(-99.173, 19.423)
+    buffer_small = center.buffer(0.02, resolution=32)
+    buffer_large = center.buffer(0.06, resolution=32)
+
+    return {
+        "triangle": triangle,
+        "buffer_small": buffer_small,
+        "buffer_large": buffer_large,
+    }
+
+
+def time_call(fn, *args, iterations=5):
+    times = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        fn(*args)
+        times.append(time.perf_counter() - start)
+    return times
+
+
+def format_seconds(value):
+    if value < 1:
+        return f"{value * 1000:.2f} ms"
+    return f"{value:.2f} s"
+
+
+def summarize(times):
+    return {
+        "min": min(times),
+        "median": statistics.median(times),
+        "mean": statistics.mean(times),
+    }
+
+
+def run_case(name, polygon, precision, inner, iterations, validate):
+    if validate:
+        legacy = legacy_polygon_to_geohashes(polygon, precision, inner)
+        optimized = polygon_to_geohashes(polygon, precision, inner)
+        if legacy != optimized:
+            raise RuntimeError(f"Mismatch for {name} (inner={inner})")
+
+    legacy_times = time_call(
+        legacy_polygon_to_geohashes, polygon, precision, inner, iterations=iterations
+    )
+    optimized_times = time_call(
+        polygon_to_geohashes, polygon, precision, inner, iterations=iterations
+    )
+
+    legacy_stats = summarize(legacy_times)
+    optimized_stats = summarize(optimized_times)
+    speedup = legacy_stats["median"] / optimized_stats["median"]
+
+    mode = "inner" if inner else "outer"
+    print(f"{name} | precision={precision} | mode={mode}")
+    print(
+        f"  legacy:    {format_seconds(legacy_stats['median'])} median "
+        f"(min {format_seconds(legacy_stats['min'])})"
+    )
+    print(
+        f"  optimized: {format_seconds(optimized_stats['median'])} median "
+        f"(min {format_seconds(optimized_stats['min'])})"
+    )
+    print(f"  speedup:   {speedup:.2f}x")
+    print("")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare legacy vs optimized polygon_to_geohashes performance."
+    )
+    parser.add_argument("--iterations", type=int, default=5)
+    parser.add_argument("--precision", type=int, default=7)
+    parser.add_argument("--inner", action="store_true", help="Only benchmark inner=True")
+    parser.add_argument("--outer", action="store_true", help="Only benchmark inner=False")
+    parser.add_argument(
+        "--no-validate",
+        action="store_true",
+        help="Skip output validation between legacy and optimized.",
+    )
+    args = parser.parse_args()
+
+    if args.inner and not args.outer:
+        modes = [True]
+    elif args.outer and not args.inner:
+        modes = [False]
+    else:
+        modes = [True, False]
+
+    polygons = build_polygons()
+    for name, polygon in polygons.items():
+        for inner in modes:
+            run_case(
+                name,
+                polygon,
+                args.precision,
+                inner,
+                args.iterations,
+                validate=not args.no_validate,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/polygon_geohasher/__init__.py
+++ b/polygon_geohasher/__init__.py
@@ -1,1 +1,10 @@
+from .polygon_geohasher import geohash_to_polygon, geohashes_to_polygon, polygon_to_geohashes
+from .version import VERSION, __version__
 
+__all__ = [
+    "VERSION",
+    "__version__",
+    "geohash_to_polygon",
+    "geohashes_to_polygon",
+    "polygon_to_geohashes",
+]

--- a/polygon_geohasher/polygon_geohasher.py
+++ b/polygon_geohasher/polygon_geohasher.py
@@ -1,8 +1,19 @@
+from collections import deque
+
 import geohash
-import queue
 
 from shapely import geometry
-from shapely.ops import cascaded_union
+from shapely.ops import unary_union
+from shapely.prepared import prep
+
+
+def _geohash_bbox(geo):
+    lat_centroid, lng_centroid, lat_offset, lng_offset = geohash.decode_exactly(geo)
+    minx = lng_centroid - lng_offset
+    maxx = lng_centroid + lng_offset
+    miny = lat_centroid - lat_offset
+    maxy = lat_centroid + lat_offset
+    return minx, miny, maxx, maxy
 
 
 def geohash_to_polygon(geo):
@@ -10,14 +21,8 @@ def geohash_to_polygon(geo):
     :param geo: String that represents the geohash.
     :return: Returns a Shapely's Polygon instance that represents the geohash.
     """
-    lat_centroid, lng_centroid, lat_offset, lng_offset = geohash.decode_exactly(geo)
-
-    corner_1 = (lat_centroid - lat_offset, lng_centroid - lng_offset)[::-1]
-    corner_2 = (lat_centroid - lat_offset, lng_centroid + lng_offset)[::-1]
-    corner_3 = (lat_centroid + lat_offset, lng_centroid + lng_offset)[::-1]
-    corner_4 = (lat_centroid + lat_offset, lng_centroid - lng_offset)[::-1]
-
-    return geometry.Polygon([corner_1, corner_2, corner_3, corner_4, corner_1])
+    minx, miny, maxx, maxy = _geohash_bbox(geo)
+    return geometry.box(minx, miny, maxx, maxy)
 
 
 def polygon_to_geohashes(polygon, precision, inner=True):
@@ -27,47 +32,58 @@ def polygon_to_geohashes(polygon, precision, inner=True):
     :param inner: bool, default 'True'. If false, geohashes that are completely outside from the polygon are ignored.
     :return: set. Set of geohashes that form the polygon.
     """
+    if polygon.is_empty:
+        return set()
+
     inner_geohashes = set()
-    outer_geohashes = set()
+    visited = set()
+    bounds = polygon.bounds
+    minx_bound, miny_bound, maxx_bound, maxy_bound = bounds
+    prepared_polygon = prep(polygon)
 
-    envelope = polygon.envelope
     centroid = polygon.centroid
+    testing_geohashes = deque()
+    testing_geohashes.append(geohash.encode(centroid.y, centroid.x, precision))
+    neighbors = geohash.neighbors
+    contains = prepared_polygon.contains
+    intersects = prepared_polygon.intersects
 
-    testing_geohashes = queue.Queue()
-    testing_geohashes.put(geohash.encode(centroid.y, centroid.x, precision))
+    while testing_geohashes:
+        current_geohash = testing_geohashes.popleft()
+        if current_geohash in visited:
+            continue
+        visited.add(current_geohash)
 
-    while not testing_geohashes.empty():
-        current_geohash = testing_geohashes.get()
+        minx, miny, maxx, maxy = _geohash_bbox(current_geohash)
+        if inner:
+            if (
+                minx < minx_bound
+                or miny < miny_bound
+                or maxx > maxx_bound
+                or maxy > maxy_bound
+            ):
+                continue
+        else:
+            if (
+                maxx < minx_bound
+                or maxy < miny_bound
+                or minx > maxx_bound
+                or miny > maxy_bound
+            ):
+                continue
 
-        if (
-            current_geohash not in inner_geohashes
-            and current_geohash not in outer_geohashes
-        ):
-            current_polygon = geohash_to_polygon(current_geohash)
+        current_polygon = geometry.box(minx, miny, maxx, maxy)
 
-            condition = (
-                envelope.contains(current_polygon)
-                if inner
-                else envelope.intersects(current_polygon)
-            )
+        if inner:
+            if contains(current_polygon):
+                inner_geohashes.add(current_geohash)
+        else:
+            if intersects(current_polygon):
+                inner_geohashes.add(current_geohash)
 
-            if condition:
-                if inner:
-                    if polygon.contains(current_polygon):
-                        inner_geohashes.add(current_geohash)
-                    else:
-                        outer_geohashes.add(current_geohash)
-                else:
-                    if polygon.intersects(current_polygon):
-                        inner_geohashes.add(current_geohash)
-                    else:
-                        outer_geohashes.add(current_geohash)
-                for neighbor in geohash.neighbors(current_geohash):
-                    if (
-                        neighbor not in inner_geohashes
-                        and neighbor not in outer_geohashes
-                    ):
-                        testing_geohashes.put(neighbor)
+        for neighbor in neighbors(current_geohash):
+            if neighbor not in visited:
+                testing_geohashes.append(neighbor)
 
     return inner_geohashes
 
@@ -77,4 +93,4 @@ def geohashes_to_polygon(geohashes):
     :param geohashes: array-like. List of geohashes to form resulting polygon.
     :return: shapely geometry. Resulting Polygon after combining geohashes.
     """
-    return cascaded_union([geohash_to_polygon(g) for g in geohashes])
+    return unary_union([geohash_to_polygon(g) for g in geohashes])

--- a/polygon_geohasher/version.py
+++ b/polygon_geohasher/version.py
@@ -5,5 +5,5 @@ def _safe_int(string):
         return string
 
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 VERSION = tuple(_safe_int(x) for x in __version__.split("."))

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,5 +1,6 @@
 import unittest
 
+import polygon_geohasher as pgh
 from polygon_geohasher.polygon_geohasher import (
     polygon_to_geohashes,
     geohash_to_polygon,
@@ -9,6 +10,11 @@ from shapely import geometry
 
 
 class TestSimpleMethods(unittest.TestCase):
+    def test_top_level_exports(self):
+        self.assertIs(pgh.polygon_to_geohashes, polygon_to_geohashes)
+        self.assertIs(pgh.geohash_to_polygon, geohash_to_polygon)
+        self.assertIs(pgh.geohashes_to_polygon, geohashes_to_polygon)
+
     def test_one_geohash(self):
         test_geohash = "x1"
         test_polygon = geohash_to_polygon(test_geohash)
@@ -37,6 +43,15 @@ class TestSimpleMethods(unittest.TestCase):
         polygon = geohashes_to_polygon(polygon_to_geohashes(test_polygon, 7, False))
 
         self.assertTrue(polygon.area >= test_polygon.area)
+
+    def test_empty_polygon(self):
+        test_polygon = geometry.Polygon()
+        self.assertTrue(test_polygon.is_empty)
+        self.assertEqual(polygon_to_geohashes(test_polygon, 5), set())
+
+    def test_empty_geohashes(self):
+        polygon = geohashes_to_polygon(set())
+        self.assertTrue(polygon.is_empty)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
• Speed up `polygon_to_geohashes` with bbox gating, prepared geometry predicates, and a faster queue.
• Replace cascaded_union with unary_union.
• Expose top-level imports in `polygon_geohasher/__init__.py`.
• Add a benchmark script, extend tests, and update `README` usage/benchmarking docs.

## Why
• Reduce runtime on larger polygons without changing public behavior.
• Make performance comparisons and usage clearer.

## How
• Add `_geohash_bbox`, use geometry.box, prep, bounds checks, and deque + visited.
• Add `benchmarks/polygon_to_geohashes.py` to compare legacy vs optimized with validation.
• Add tests for top-level exports/empty inputs and update `README` import + benchmark instructions.