### PR TITLE
perf: add hierarchical geohash cover

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ inner_geohashes_polygon = geohashes_to_polygon(polygon_to_geohashes(polygon, 7))
 outer_geohashes_polygon = geohashes_to_polygon(polygon_to_geohashes(polygon, 7, False))
 ```
 
+## Algorithm
+`polygon_to_geohashes` uses a hierarchical geohash cover. It starts with a coarse
+precision cover of the polygon bounds, discards cells that do not intersect the
+polygon, and only subdivides boundary cells until the target precision. Cells
+that are fully contained are expanded directly to the target precision without
+additional geometry checks. This keeps work closer to boundary complexity than
+to the full bounding box.
+
 ## Benchmarking
 Compare the optimized implementation against the legacy algorithm:
 

--- a/polygon_geohasher/polygon_geohasher.py
+++ b/polygon_geohasher/polygon_geohasher.py
@@ -6,6 +6,8 @@ from shapely import geometry
 from shapely.ops import unary_union
 from shapely.prepared import prep
 
+_BASE32 = "0123456789bcdefghjkmnpqrstuvwxyz"
+
 
 def _geohash_bbox(geo):
     lat_centroid, lng_centroid, lat_offset, lng_offset = geohash.decode_exactly(geo)
@@ -14,6 +16,61 @@ def _geohash_bbox(geo):
     miny = lat_centroid - lat_offset
     maxy = lat_centroid + lat_offset
     return minx, miny, maxx, maxy
+
+
+def _bounds_intersect(bounds, other_bounds):
+    minx, miny, maxx, maxy = bounds
+    ominx, ominy, omaxx, omaxy = other_bounds
+    if maxx < ominx or omaxx < minx:
+        return False
+    if maxy < ominy or omaxy < miny:
+        return False
+    return True
+
+
+def _cover_bounds(bounds, precision):
+    minx, miny, maxx, maxy = bounds
+    center_lat = (miny + maxy) / 2.0
+    center_lon = (minx + maxx) / 2.0
+    start = geohash.encode(center_lat, center_lon, precision)
+
+    queue = deque([start])
+    visited = set()
+    results = []
+    neighbors = geohash.neighbors
+
+    while queue:
+        current = queue.popleft()
+        if current in visited:
+            continue
+        visited.add(current)
+
+        current_bounds = _geohash_bbox(current)
+        if not _bounds_intersect(current_bounds, bounds):
+            continue
+
+        results.append(current)
+        for neighbor in neighbors(current):
+            if neighbor not in visited:
+                queue.append(neighbor)
+
+    return results
+
+
+def _expand_children(prefix, target_precision, out_set):
+    if len(prefix) == target_precision:
+        out_set.add(prefix)
+        return
+
+    stack = [prefix]
+    base32 = _BASE32
+    while stack:
+        current = stack.pop()
+        if len(current) == target_precision:
+            out_set.add(current)
+            continue
+        for char in base32:
+            stack.append(current + char)
 
 
 def geohash_to_polygon(geo):
@@ -35,57 +92,48 @@ def polygon_to_geohashes(polygon, precision, inner=True):
     if polygon.is_empty:
         return set()
 
-    inner_geohashes = set()
-    visited = set()
-    bounds = polygon.bounds
-    minx_bound, miny_bound, maxx_bound, maxy_bound = bounds
     prepared_polygon = prep(polygon)
+    bounds = polygon.bounds
+    seed_precision = min(precision, 3)
+    seeds = _cover_bounds(bounds, seed_precision)
 
-    centroid = polygon.centroid
-    testing_geohashes = deque()
-    testing_geohashes.append(geohash.encode(centroid.y, centroid.x, precision))
-    neighbors = geohash.neighbors
+    results = set()
+    stack = list(seeds)
     contains = prepared_polygon.contains
     intersects = prepared_polygon.intersects
 
-    while testing_geohashes:
-        current_geohash = testing_geohashes.popleft()
-        if current_geohash in visited:
+    while stack:
+        current = stack.pop()
+        current_bounds = _geohash_bbox(current)
+        if not _bounds_intersect(current_bounds, bounds):
             continue
-        visited.add(current_geohash)
 
-        minx, miny, maxx, maxy = _geohash_bbox(current_geohash)
-        if inner:
-            if (
-                minx < minx_bound
-                or miny < miny_bound
-                or maxx > maxx_bound
-                or maxy > maxy_bound
-            ):
-                continue
-        else:
-            if (
-                maxx < minx_bound
-                or maxy < miny_bound
-                or minx > maxx_bound
-                or miny > maxy_bound
-            ):
-                continue
-
-        current_polygon = geometry.box(minx, miny, maxx, maxy)
+        current_polygon = geometry.box(*current_bounds)
+        if not intersects(current_polygon):
+            continue
 
         if inner:
             if contains(current_polygon):
-                inner_geohashes.add(current_geohash)
+                if len(current) == precision:
+                    results.add(current)
+                else:
+                    _expand_children(current, precision, results)
+            elif len(current) < precision:
+                for char in _BASE32:
+                    stack.append(current + char)
+            continue
+
+        if len(current) == precision:
+            results.add(current)
+            continue
+
+        if contains(current_polygon):
+            _expand_children(current, precision, results)
         else:
-            if intersects(current_polygon):
-                inner_geohashes.add(current_geohash)
+            for char in _BASE32:
+                stack.append(current + char)
 
-        for neighbor in neighbors(current_geohash):
-            if neighbor not in visited:
-                testing_geohashes.append(neighbor)
-
-    return inner_geohashes
+    return results
 
 
 def geohashes_to_polygon(geohashes):

--- a/polygon_geohasher/version.py
+++ b/polygon_geohasher/version.py
@@ -5,5 +5,5 @@ def _safe_int(string):
         return string
 
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 VERSION = tuple(_safe_int(x) for x in __version__.split("."))

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -53,6 +53,65 @@ class TestSimpleMethods(unittest.TestCase):
         polygon = geohashes_to_polygon(set())
         self.assertTrue(polygon.is_empty)
 
+    def test_inner_geohashes_are_contained(self):
+        polygon = geometry.box(-1.0, -1.0, 1.0, 1.0)
+        geohashes = polygon_to_geohashes(polygon, 4, True)
+        self.assertTrue(geohashes)
+        self.assertTrue(
+            all(polygon.contains(geohash_to_polygon(g)) for g in geohashes)
+        )
+
+    def test_outer_geohashes_intersect(self):
+        shell = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0), (-1.0, -1.0)]
+        hole = [
+            (-0.2, -0.2),
+            (0.2, -0.2),
+            (0.2, 0.2),
+            (-0.2, 0.2),
+            (-0.2, -0.2),
+        ]
+        polygon = geometry.Polygon(shell, [hole])
+        geohashes = polygon_to_geohashes(polygon, 4, False)
+        self.assertTrue(geohashes)
+        self.assertTrue(
+            all(polygon.intersects(geohash_to_polygon(g)) for g in geohashes)
+        )
+
+    def test_inner_geohashes_respect_holes(self):
+        shell = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0), (-1.0, -1.0)]
+        hole = [
+            (-0.2, -0.2),
+            (0.2, -0.2),
+            (0.2, 0.2),
+            (-0.2, 0.2),
+            (-0.2, -0.2),
+        ]
+        polygon = geometry.Polygon(shell, [hole])
+        hole_polygon = geometry.Polygon(hole)
+        geohashes = polygon_to_geohashes(polygon, 4, True)
+        self.assertTrue(geohashes)
+        self.assertTrue(all(len(g) == 4 for g in geohashes))
+        self.assertTrue(
+            all(polygon.contains(geohash_to_polygon(g)) for g in geohashes)
+        )
+        self.assertTrue(
+            all(not hole_polygon.intersects(geohash_to_polygon(g)) for g in geohashes)
+        )
+
+    def test_outer_geohashes_intersect_multipolygon(self):
+        polygon = geometry.MultiPolygon(
+            [
+                geometry.box(-2.0, -2.0, -1.0, -1.0),
+                geometry.box(1.0, 1.0, 2.0, 2.0),
+            ]
+        )
+        geohashes = polygon_to_geohashes(polygon, 3, False)
+        self.assertTrue(geohashes)
+        self.assertTrue(all(len(g) == 3 for g in geohashes))
+        self.assertTrue(
+            all(polygon.intersects(geohash_to_polygon(g)) for g in geohashes)
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What
- Replace the BFS flood-fill with a hierarchical geohash cover in `polygon_to_geohashes`.
- Add tests for holes, multipolygons, and precision length guarantees.
- Document the new algorithm in the README.
- Bump the version to 0.0.3.

## Why
- Reduce geometry predicate calls and runtime on large or sparse polygons.
- Ensure correctness across holes and multipolygon inputs.
- Make the algorithm and its performance characteristics explicit for users.

## How
- Seed a coarse cover of polygon bounds, discard non-intersecting cells, and subdivide only boundary cells.
- Expand fully contained cells directly to target precision.
- Validate behavior with new tests and document the approach.
